### PR TITLE
fix typo in first line of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Evie
 
-Evie provides an EventEmtter-style interface, but provides support for event-bubbling.
+Evie provides an EventEmitter-style interface, but provides support for event-bubbling.
 
 ```coffee-script
 parent = new Evie


### PR DESCRIPTION
ToDo: link to [EventEmitter](https://www.npmjs.com/package/eventemitter)